### PR TITLE
Making Level

### DIFF
--- a/src/generator/maze.rs
+++ b/src/generator/maze.rs
@@ -24,13 +24,14 @@ impl MazeGen {
     }
 
     pub fn generate(&mut self, level: &mut Level<Tile>) {
+        use util::Error;
         let mut stack: Vec<Vec2<usize>> = Vec::new();
         stack.push(self.pos);
         'mainloop: while let Some(cur) = stack.pop() {
             let neighbours = Self::get_neighbours(level, &cur);
             match level.get_mut_tile_with_vec(&cur) {
 
-                Some(tile) => {
+                Ok(tile) => {
                     match *tile {
                         Tile::Void(_) | Tile::Floor(_) => {continue 'mainloop},
                         _ => {},
@@ -47,7 +48,7 @@ impl MazeGen {
                     }
                 },
 
-                None => continue 'mainloop
+                Err(Error::IndexOutOfBounds) => continue 'mainloop
             }
 
         }
@@ -61,8 +62,8 @@ impl MazeGen {
             let dvec = d.get_vec();
             pos.x = (pos.x as isize + dvec.x) as usize;
             pos.y = (pos.y as isize + dvec.y) as usize;
-            match level[pos] {
-                Some(Tile::Floor(_)) => {
+            match level.get_tile_with_vec(&pos) {
+                Ok(&Tile::Floor(_)) => {
                     floors += 1;
                     if floors > 1 {
                         return None;

--- a/src/generator/room.rs
+++ b/src/generator/room.rs
@@ -72,13 +72,14 @@ impl RoomGen {
     }
 
     fn carve(&self, level: &mut Level<Tile>) {
+        use util::Error;
         let room_distance = self.room_distance.clone();
         for room in &self.rooms {
             for y in room.min.y..room.max.y-room_distance+1 {
                 for x in room.min.x..room.max.x-room_distance+1 {
                     match level.get_mut_tile(x, y) {
-                        Some(tile) => *tile = Tile::Floor(0),
-                        None => {}
+                        Ok(tile) => *tile = Tile::Floor(0),
+                        Err(Error::IndexOutOfBounds) => {}
                     }
                 }
             }

--- a/src/level.rs
+++ b/src/level.rs
@@ -1,6 +1,5 @@
 use tile::Tile;
 use util::{Grid, Error};
-use std::ops::{Index};
 use na::Vec2;
 use std::default::Default;
 
@@ -19,7 +18,7 @@ impl<T> Level<T> {
 
     pub fn get_tile(&self, x: usize, y: usize) -> Result<&T, Error> {
         if x < self.get_width() && y < self.get_height() {
-            Ok(self.tiles[(x, y)])
+            Ok(&self.tiles[(x, y)])
         } else {
             Err(Error::IndexOutOfBounds)
         }
@@ -35,7 +34,7 @@ impl<T> Level<T> {
 
     pub fn get_mut_tile(&mut self, x: usize, y: usize) -> Result<&mut T, Error> {
         if x < self.get_width() && y < self.get_height() {
-            Ok(self.tiles[(x, y)].as_mut())
+            Ok(&mut self.tiles[(x, y)])
         } else {
             Err(Error::IndexOutOfBounds)
         }

--- a/src/level.rs
+++ b/src/level.rs
@@ -80,35 +80,6 @@ impl<T: Clone> Level<T> {
     }
 }
 
-<<<<<<< Updated upstream
-static NONE: &'static Option<()> = &None;
-
-impl<T> Index<(usize, usize)> for Level<T> {
-    type Output= Option<T>;
-
-    fn index(&self, (x, y): (usize, usize)) -> &Option<T>{
-        if x < self.get_width() && y < self.get_height() {
-            &self.tiles[(x, y)]
-        } else {
-             unsafe{&*(NONE as *const _ as *const _)} //delmas pointer magic
-        }
-    }
-}
-
-impl<T> Index<Vec2<usize>> for Level<T> {
-    type Output= Option<T>;
-
-    fn index(&self, vec: Vec2<usize>) -> &Option<T>{
-        if vec.x < self.get_width() && vec.y < self.get_height() {
-            &self.tiles[(vec.x, vec.y)]
-        } else {
-             unsafe{&*(NONE as *const _ as *const _)} //delmas pointer magic
-        }
-    }
-}
-
-=======
->>>>>>> Stashed changes
 pub fn fill_dead_end_tiles(level: &mut Level<Tile>) -> bool {
     let mut deadends = Vec::new();
     for y in 0..level.get_height() {

--- a/src/level.rs
+++ b/src/level.rs
@@ -4,7 +4,7 @@ use std::ops::{Index};
 use na::Vec2;
 
 pub struct Level<T> {
-    tiles: Grid<Option<T>>,
+    tiles: Grid<T>,
 }
 
 impl<T> Level<T> {
@@ -14,6 +14,22 @@ impl<T> Level<T> {
 
     pub fn get_height(&self) -> usize {
         self.tiles.get_height()
+    }
+
+    pub fn get_tile(&self, x: usize, y: usize) -> Option<&T> {
+        if x < self.get_width() && y < self.get_height() {
+            self.tiles[(x, y)]
+        } else {
+            None
+        }
+    }
+
+    pub fn get_tile_with_vec(&self, pos: &Vec2<usize>) -> Option<&T> {
+        self.get_tile(pos.x, pos.y)
+    }
+
+    pub fn get_tile_with_tuple(&self, (x, y): (usize, usize)) -> Option<&T> {
+        self.get_tile(x,y)
     }
 
     pub fn get_mut_tile(&mut self, x: usize, y: usize) -> Option<&mut T> {
@@ -26,6 +42,10 @@ impl<T> Level<T> {
 
     pub fn get_mut_tile_with_vec(&mut self, pos: &Vec2<usize>) -> Option<&mut T> {
         self.get_mut_tile(pos.x, pos.y)
+    }
+
+    pub fn get_mut_tile_with_tuple(&mut self, (x, y): (usize, usize)) -> Option<&mut T> {
+        self.get_mut_tile(x,y)
     }
 
     pub fn apply<F>(&mut self, gen: F) -> &mut Level<T> where F: FnOnce(&mut Level<T>) {
@@ -60,6 +80,7 @@ impl<T: Clone> Level<T> {
     }
 }
 
+<<<<<<< Updated upstream
 static NONE: &'static Option<()> = &None;
 
 impl<T> Index<(usize, usize)> for Level<T> {
@@ -86,11 +107,13 @@ impl<T> Index<Vec2<usize>> for Level<T> {
     }
 }
 
+=======
+>>>>>>> Stashed changes
 pub fn fill_dead_end_tiles(level: &mut Level<Tile>) -> bool {
     let mut deadends = Vec::new();
     for y in 0..level.get_height() {
         for x in 0..level.get_width() {
-            if let Some(ref n) = level[(x,y)] {
+            if let Some(n) = level.get_tile(x, y) {
                 if let &Tile::Floor(_) = n {
                     if is_deadend(level, x, y) {
                         deadends.push((x,y));
@@ -119,7 +142,7 @@ pub fn is_deadend(level: &Level<Tile>, x: usize, y: usize) -> bool {
             _ => continue,
         };
 
-        if let Some(Tile::Floor(_)) = level[coord] {
+        if let Some(&Tile::Floor(_)) = level.get_tile_with_tuple(coord) {
             paths += 1;
         }
     }

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,3 +1,5 @@
+use std::default::Default;
+
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 //the indexes inside the enums are for flexibility. You can create an extra array for different
 //types of particular tile type and index it with the index. For example you could have an array of

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -9,3 +9,9 @@ pub enum Tile {
     Floor(usize),
     Void(usize),
 }
+
+impl Default for Tile {
+    fn default() -> Tile {
+        Tile::Void(0)
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -82,3 +82,7 @@ impl Direction {
 		&ORTHOGONAL
 	}
 }
+
+pub enum Error {
+    IndexOutOfBounds,
+}


### PR DESCRIPTION
Level struct was made into a more generic struct because I don't want to clutter the tile enum with bunch of different variant sets that arent used together.
