### PR TITLE
Dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dungenon"
-version = "0.1.0"
+version = "0.4.0"
 authors = ["VoxWave <victor_bankowski@hotmail.com>"]
 
 [dependencies]

--- a/src/generator/faction.rs
+++ b/src/generator/faction.rs
@@ -1,18 +1,25 @@
 use rand::os::OsRng;
 use rand::XorShiftRng;
+use rand::Rand;
+use rand::Rng;
+
+use tile::Faction;
 
 pub struct FactionGen {
     rand: XorShiftRng,
-    faction_amount: usize.
+    faction_amount: usize,
 }
 
 impl FactionGen {
-	pub fn new(faction_amount: usize) {
-		rand: XorShiftRng::rand(&mut OsRng::new().unwrap()),
-		faction_amount: faction_amount,
+	pub fn new(faction_amount: usize) -> FactionGen {
+        FactionGen {
+            rand: XorShiftRng::rand(&mut OsRng::new().unwrap()),
+            faction_amount: faction_amount,
+        }
 	}
 
 	pub fn generate(&mut self, level: &mut Level<Faction>) {
+        let delta = Vec::new();
 		for x in 0..level.get_width() {
 			for y in 0..level.get_height() {
 				match level.get_mut_tile(x, y) {
@@ -20,14 +27,14 @@ impl FactionGen {
 						let mut deck = Vec::new();
 						match *tile {
 							Faction::Faction(_) => {
-								deck.push(tile);
+								deck.push(tile.clone());
 							},
 							Faction::Void => continue,
 							_ => {},
 						}
 						get_faction_neighbours(&mut deck, &mut level);
-						self.rand.shuffle(deck);
-						*tile = deck.pop();
+						self.rand.shuffle(&mut deck);
+						delta.push(((x,y),deck.pop()));
 					},
 					Err(Error::IndexOutOfBounds) => {
 						panic!("Generate method indexed out of bounds while simulating a step. This should never happen unless the programmer is not very bright.");
@@ -35,5 +42,12 @@ impl FactionGen {
 				}
 			}
 		}
+        Self::applyChanges(level, delta);
 	}
+
+    fn applyChanges(level: &mut Level<Faction>, delta: Vec<((usize, usize), Faction)>) {
+        for ((x, y), f) in delta {
+            level.get_mut_tile(x,y).unwrap()* = f;
+        }
+    }
 }

--- a/src/generator/faction.rs
+++ b/src/generator/faction.rs
@@ -19,7 +19,9 @@ impl FactionGen {
 					Ok(tile) => {
 
 					},
-					Err(Error::IndexOutOfBounds) => panic!("");
+					Err(Error::IndexOutOfBounds) => {
+						panic!("Generate method indexed out of bounds while simulating a step. This should never happen unless the programmer is not very bright.");
+					}
 				}
 			}
 		}

--- a/src/generator/faction.rs
+++ b/src/generator/faction.rs
@@ -41,10 +41,9 @@ impl FactionGen {
                     }
                 }
                 Self::get_faction_neighbours(x, y, &mut deck, level);
-                self.rand.shuffle(&mut deck);
-                match deck.pop() {
+                match self.rand.choose(&deck) {
                     Some(f) => {
-                        delta.push(((x,y), f));
+                        delta.push(((x,y), f.clone()));
                     },
                     None => continue,
                 }

--- a/src/generator/faction.rs
+++ b/src/generator/faction.rs
@@ -1,0 +1,27 @@
+use rand::os::OsRng;
+use rand::XorShiftRng;
+
+pub struct FactionGen {
+    rand: XorShiftRng,
+    faction_amount: usize.
+}
+
+impl FactionGen {
+	pub fn new(faction_amount: usize) {
+		rand: XorShiftRng::rand(&mut OsRng::new().unwrap()),
+		faction_amount: faction_amount,
+	}
+
+	pub fn generate(&mut self, level: &mut Level<Faction>) {
+		for x in 0..level.get_width() {
+			for y in 0..level.get_height() {
+				match level.get_mut_tile(x, y) {
+					Ok(tile) => {
+
+					},
+					Err(Error::IndexOutOfBounds) => panic!("");
+				}
+			}
+		}
+	}
+}

--- a/src/generator/faction.rs
+++ b/src/generator/faction.rs
@@ -11,43 +11,50 @@ pub struct FactionGen {
 }
 
 impl FactionGen {
-	pub fn new(faction_amount: usize) -> FactionGen {
+    pub fn new(faction_amount: usize) -> FactionGen {
         FactionGen {
             rand: XorShiftRng::rand(&mut OsRng::new().unwrap()),
             faction_amount: faction_amount,
         }
-	}
+    }
 
-	pub fn generate(&mut self, level: &mut Level<Faction>) {
+    pub fn generate(&mut self, level: &mut Level<Faction>) {
         let delta = Vec::new();
-		for x in 0..level.get_width() {
-			for y in 0..level.get_height() {
-				match level.get_mut_tile(x, y) {
-					Ok(tile) => {
-						let mut deck = Vec::new();
-						match *tile {
-							Faction::Faction(_) => {
-								deck.push(tile.clone());
-							},
-							Faction::Void => continue,
-							_ => {},
-						}
-						get_faction_neighbours(&mut deck, &mut level);
-						self.rand.shuffle(&mut deck);
-						delta.push(((x,y),deck.pop()));
-					},
-					Err(Error::IndexOutOfBounds) => {
-						panic!("Generate method indexed out of bounds while simulating a step. This should never happen unless the programmer is not very bright.");
-					}
-				}
-			}
-		}
+        for x in 0..level.get_width() {
+            for y in 0..level.get_height() {
+                match level.get_mut_tile(x, y) {
+                    Ok(tile) => {
+                        let mut deck = Vec::new();
+                        match *tile {
+                            Faction::Faction(_) => {
+                                deck.push(tile.clone());
+                            },
+                            Faction::Void => continue,
+                            _ => {},
+                        }
+                        get_faction_neighbours(&mut deck, &mut level);
+                        self.rand.shuffle(&mut deck);
+                        match deck.pop() {
+                            Some(f) => {
+                                delta.push(((x,y), f));
+                            },
+                            None => continue,
+                        }
+                    },
+                    Err(Error::IndexOutOfBounds) => {
+                        panic!("Generate method indexed out of bounds while simulating a step. This should never happen unless the programmer is not very bright.");
+                    }
+                }
+            }
+        }
         Self::applyChanges(level, delta);
-	}
+    }
 
     fn applyChanges(level: &mut Level<Faction>, delta: Vec<((usize, usize), Faction)>) {
         for ((x, y), f) in delta {
-            level.get_mut_tile(x,y).unwrap()* = f;
+            if let Ok(tile) = level.get_mut_tile(x, y) {
+                *tile = f;
+            }
         }
     }
 }

--- a/src/generator/faction.rs
+++ b/src/generator/faction.rs
@@ -21,10 +21,10 @@ impl FactionGen {
     }
 
     pub fn generate(&mut self, level: &mut Level<Faction>) {
-        let mut delta = Vec::new();
+        let mut delta = Vec::with_capacity(level.get_width() * level.get_height());
         for x in 0..level.get_width() {
             for y in 0..level.get_height() {
-                let mut deck = Vec::new();
+                let mut deck = Vec::with_capacity(9);
                 match level.get_mut_tile(x, y) {
                     Ok(tile) => {
                         match *tile {
@@ -37,7 +37,7 @@ impl FactionGen {
 
                     },
                     Err(Error::IndexOutOfBounds) => {
-                        panic!("Generate method indexed out of bounds while simulating a step. This should never happen unless the programmer is not very bright.");
+                        unreachable!("Generate method indexed out of bounds while simulating a step. This should never happen unless the programmer is not very bright.");
                     }
                 }
                 Self::get_faction_neighbours(x, y, &mut deck, level);

--- a/src/generator/faction.rs
+++ b/src/generator/faction.rs
@@ -17,7 +17,17 @@ impl FactionGen {
 			for y in 0..level.get_height() {
 				match level.get_mut_tile(x, y) {
 					Ok(tile) => {
-
+						let mut deck = Vec::new();
+						match *tile {
+							Faction::Faction(_) => {
+								deck.push(tile);
+							},
+							Faction::Void => continue,
+							_ => {},
+						}
+						get_faction_neighbours(&mut deck, &mut level);
+						self.rand.shuffle(deck);
+						*tile = deck.pop();
 					},
 					Err(Error::IndexOutOfBounds) => {
 						panic!("Generate method indexed out of bounds while simulating a step. This should never happen unless the programmer is not very bright.");

--- a/src/generator/faction.rs
+++ b/src/generator/faction.rs
@@ -5,26 +5,28 @@ use rand::Rng;
 
 use tile::Faction;
 
+use util::{Error, Direction};
+
+use level::{Level, add_isize_to_usize};
+
 pub struct FactionGen {
     rand: XorShiftRng,
-    faction_amount: usize,
 }
 
 impl FactionGen {
-    pub fn new(faction_amount: usize) -> FactionGen {
+    pub fn new() -> FactionGen {
         FactionGen {
             rand: XorShiftRng::rand(&mut OsRng::new().unwrap()),
-            faction_amount: faction_amount,
         }
     }
 
     pub fn generate(&mut self, level: &mut Level<Faction>) {
-        let delta = Vec::new();
+        let mut delta = Vec::new();
         for x in 0..level.get_width() {
             for y in 0..level.get_height() {
+                let mut deck = Vec::new();
                 match level.get_mut_tile(x, y) {
                     Ok(tile) => {
-                        let mut deck = Vec::new();
                         match *tile {
                             Faction::Faction(_) => {
                                 deck.push(tile.clone());
@@ -32,25 +34,40 @@ impl FactionGen {
                             Faction::Void => continue,
                             _ => {},
                         }
-                        get_faction_neighbours(&mut deck, &mut level);
-                        self.rand.shuffle(&mut deck);
-                        match deck.pop() {
-                            Some(f) => {
-                                delta.push(((x,y), f));
-                            },
-                            None => continue,
-                        }
+
                     },
                     Err(Error::IndexOutOfBounds) => {
                         panic!("Generate method indexed out of bounds while simulating a step. This should never happen unless the programmer is not very bright.");
                     }
                 }
+                Self::get_faction_neighbours(x, y, &mut deck, level);
+                self.rand.shuffle(&mut deck);
+                match deck.pop() {
+                    Some(f) => {
+                        delta.push(((x,y), f));
+                    },
+                    None => continue,
+                }
             }
         }
-        Self::applyChanges(level, delta);
+        Self::apply_changes(level, delta);
     }
 
-    fn applyChanges(level: &mut Level<Faction>, delta: Vec<((usize, usize), Faction)>) {
+    fn get_faction_neighbours(x: usize, y: usize, deck: &mut Vec<Faction>, level: &mut Level<Faction>) {
+        for d in Direction::get_dirs() {
+            let (ix, iy) = d.get_tuple();
+            let coord = match (add_isize_to_usize(ix, x), add_isize_to_usize(iy, y)) {
+                (Some(x), Some(y)) => (x,y),
+                _ => continue,
+            };
+            match level.get_tile_with_tuple(coord) {
+                Ok(f @ &Faction::Faction(_)) => deck.push(f.clone()),
+                _ => {},
+            }
+        }
+    }
+
+    fn apply_changes(level: &mut Level<Faction>, delta: Vec<((usize, usize), Faction)>) {
         for ((x, y), f) in delta {
             if let Ok(tile) = level.get_mut_tile(x, y) {
                 *tile = f;

--- a/src/generator/maze.rs
+++ b/src/generator/maze.rs
@@ -1,4 +1,4 @@
-use level::Level;
+use level::{add_isize_to_usize, Level};
 
 use na::Vec2;
 
@@ -58,11 +58,13 @@ impl MazeGen {
         let mut neighbours: Vec<Vec2<usize>> = Vec::new();
         let mut floors = 0;
         for d in Direction::get_orthogonal_dirs() {
-            let mut pos = pos.clone();
+            let pos = pos.clone();
             let dvec = d.get_vec();
-            pos.x = (pos.x as isize + dvec.x) as usize;
-            pos.y = (pos.y as isize + dvec.y) as usize;
-            match level.get_tile_with_vec(&pos) {
+            let coord = match (add_isize_to_usize(dvec.x, pos.x), add_isize_to_usize(dvec.y, pos.y)) {
+                (Some(x), Some(y)) => (x,y),
+                _ => continue,
+            };
+            match level.get_tile_with_tuple(coord) {
                 Ok(&Tile::Floor(_)) => {
                     floors += 1;
                     if floors > 1 {

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -1,7 +1,9 @@
 mod dungeon;
 mod room;
 mod maze;
+mod faction;
 
 pub use self::maze::MazeGen;
 pub use self::dungeon::DungeonGen;
 pub use self::room::RoomGen;
+pub use self::faction::FactionGen;

--- a/src/level.rs
+++ b/src/level.rs
@@ -120,7 +120,7 @@ pub fn is_deadend(level: &Level<Tile>, x: usize, y: usize) -> bool {
     paths < 2
 }
 
-fn add_isize_to_usize(i: isize, mut u: usize,) -> Option<usize> {
+pub fn add_isize_to_usize(i: isize, mut u: usize,) -> Option<usize> {
     if i < 0 && u != 0 {
         u -= (-i) as usize;
     } else if i >= 0 && u < usize::max_value() {

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -17,3 +17,9 @@ impl Default for Tile {
         Tile::Void(0)
     }
 }
+
+pub enum Faction {
+	Faction(usize),
+	Neutral,
+	Void,
+}

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -18,8 +18,15 @@ impl Default for Tile {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Faction {
 	Faction(usize),
 	Neutral,
 	Void,
+}
+
+impl Default for Faction {
+    fn default() -> Faction {
+        Faction::Void
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -61,6 +61,7 @@ pub enum Direction {
 }
 
 static ORTHOGONAL: [Direction; 4] = [Direction::Up, Direction::Down, Direction::Left, Direction::Right];
+static ALL: [Direction; 8] = [Direction::Up, Direction::Down, Direction::Left, Direction::Right, Direction::Dl, Direction::Dr, Direction::Ul, Direction::Ur];
 
 impl Direction {
 	pub fn get_vec(&self) -> Vec2<isize> {
@@ -78,9 +79,26 @@ impl Direction {
 		vec
 	}
 
+    pub fn get_tuple(&self) -> (isize, isize) {
+        use self::Direction::*;
+        match *self {
+            Up => (0,1),
+			Down => (0,-1),
+			Left => (-1,0),
+			Right => (1,0),
+			Ur => (1,1),
+			Dr => (1,-1),
+			Dl => (-1,-1),
+			Ul => (-1,1),
+        }
+    }
+
 	pub fn get_orthogonal_dirs() -> &'static[Direction] {
 		&ORTHOGONAL
 	}
+    pub fn get_dirs() -> &'static[Direction] {
+        &ALL
+    }
 }
 
 pub enum Error {

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,99 +3,99 @@ use std::default::Default;
 use na::Vec2;
 
 pub struct Grid<T> {
-	data: Vec<T>,
-	width: usize,
+    data: Vec<T>,
+    width: usize,
 }
 
 impl<T> Grid<T> {
-	pub fn get_width(&self) -> usize {
-		self.width
-	}
+    pub fn get_width(&self) -> usize {
+        self.width
+    }
 
-	pub fn get_height(&self) -> usize {
-		self.data.len() / self.width
-	}
+    pub fn get_height(&self) -> usize {
+        self.data.len() / self.width
+    }
 }
 
 impl<T: Default+Clone> Grid<T> {
-	pub fn new(width:usize, height:usize) -> Grid<T> {
-		Grid{
-			data: vec![Default::default(); width * height],
-			width: width,
-		}
-	}
+    pub fn new(width:usize, height:usize) -> Grid<T> {
+        Grid{
+            data: vec![Default::default(); width * height],
+            width: width,
+        }
+    }
 }
 
 impl<T: Clone> Grid<T> {
-	pub fn new_filled_with(thing: T, width: usize, height: usize) -> Grid<T> {
-		Grid{
-			data: vec![thing; width * height],
-			width: width,
-		}
-	}
+    pub fn new_filled_with(thing: T, width: usize, height: usize) -> Grid<T> {
+        Grid{
+            data: vec![thing; width * height],
+            width: width,
+        }
+    }
 }
 
 impl<T> Index<(usize, usize)> for Grid<T> {
-	type Output= T;
+    type Output= T;
 
     fn index(&self, (x, y): (usize, usize)) -> &T{
-    	&self.data[x+y*self.width]
+        &self.data[x+y*self.width]
     }
 }
 
 impl<T> IndexMut<(usize, usize)> for Grid<T> {
-	fn index_mut(&mut self, (x, y): (usize, usize)) -> &mut T {
-		&mut self.data[x+y*self.width]
-	}
+    fn index_mut(&mut self, (x, y): (usize, usize)) -> &mut T {
+        &mut self.data[x+y*self.width]
+    }
 }
 
 pub enum Direction {
-	Up,
-	Down,
-	Left,
-	Right,
-	Ur,
-	Dr,
-	Dl,
-	Ul,
+    Up,
+    Down,
+    Left,
+    Right,
+    Ur,
+    Dr,
+    Dl,
+    Ul,
 }
 
 static ORTHOGONAL: [Direction; 4] = [Direction::Up, Direction::Down, Direction::Left, Direction::Right];
 static ALL: [Direction; 8] = [Direction::Up, Direction::Down, Direction::Left, Direction::Right, Direction::Dl, Direction::Dr, Direction::Ul, Direction::Ur];
 
 impl Direction {
-	pub fn get_vec(&self) -> Vec2<isize> {
-		use self::Direction::*;
-		let vec = match *self {
-			Up => Vec2::new(0,1),
-			Down => Vec2::new(0,-1),
-			Left => Vec2::new(-1,0),
-			Right => Vec2::new(1,0),
-			Ur => Vec2::new(1,1),
-			Dr => Vec2::new(1,-1),
-			Dl => Vec2::new(-1,-1),
-			Ul => Vec2::new(-1,1),
-		};
-		vec
-	}
+    pub fn get_vec(&self) -> Vec2<isize> {
+        use self::Direction::*;
+        let vec = match *self {
+            Up => Vec2::new(0,1),
+            Down => Vec2::new(0,-1),
+            Left => Vec2::new(-1,0),
+            Right => Vec2::new(1,0),
+            Ur => Vec2::new(1,1),
+            Dr => Vec2::new(1,-1),
+            Dl => Vec2::new(-1,-1),
+            Ul => Vec2::new(-1,1),
+        };
+        vec
+    }
 
     pub fn get_tuple(&self) -> (isize, isize) {
         use self::Direction::*;
         match *self {
             Up => (0,1),
-			Down => (0,-1),
-			Left => (-1,0),
-			Right => (1,0),
-			Ur => (1,1),
-			Dr => (1,-1),
-			Dl => (-1,-1),
-			Ul => (-1,1),
+            Down => (0,-1),
+            Left => (-1,0),
+            Right => (1,0),
+            Ur => (1,1),
+            Dr => (1,-1),
+            Dl => (-1,-1),
+            Ul => (-1,1),
         }
     }
 
-	pub fn get_orthogonal_dirs() -> &'static[Direction] {
-		&ORTHOGONAL
-	}
+    pub fn get_orthogonal_dirs() -> &'static[Direction] {
+        &ORTHOGONAL
+    }
     pub fn get_dirs() -> &'static[Direction] {
         &ALL
     }


### PR DESCRIPTION
This merge introduces the faction generator.

The basic idea was to make a simple simulation of territory conquering between different factions.
How this is implemented is that for each tile its type is checked. If it is a faction tile then it is added to a deck. If it's a neutral tile then it is not added and if it is a void tile then we skip to the next tile. next the tiles neighbours (which includes diagonal neighbours) are checked. If they are faction tiles then they are added to the deck. Finally the deck is shuffled and we pop one of the factions from it and set it to be this tiles value (unless the deck is empty in which case we do nothing to this tile).

What is supposed to happen is that factions will increase territory freely until they are very close to each other. Then factions start to fight for territory. The deck makes it so that the faction that has most territory neighbouring a tile is more likely to aquire that tile. If a tile is already under a factions control but other factions surround that tile too then there is a chance that that tile might be conquered.