### PR TITLE
Paralelisized factiongen to make it faster. UNSAFE USAGE ADDED

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ authors = ["VoxWave <victor_bankowski@hotmail.com>"]
 [dependencies]
 rand = "0.3.13"
 nalgebra = "0.5.1"
+rayon = "0.7"
+smallvec = "0.3.3"

--- a/src/level.rs
+++ b/src/level.rs
@@ -3,6 +3,7 @@ use util::{Grid, Error};
 use na::Vec2;
 use std::default::Default;
 
+#[derive(Clone)]
 pub struct Level<T> {
     tiles: Grid<T>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 extern crate nalgebra as na;
 extern crate rand;
+extern crate rayon;
+extern crate smallvec;
 
 pub mod generator;
 pub mod level;

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,7 @@ use std::ops::{Index, IndexMut};
 use std::default::Default;
 use na::Vec2;
 
+#[derive(Clone)]
 pub struct Grid<T> {
     data: Vec<T>,
     width: usize,


### PR DESCRIPTION
Using unsafe to paralelisize the apply part of the algorithm made execution significantly faster, It took 2min 36secs to simulate 1000 steps on a 1000x1000 level with two factions each one at opposite corners. It took 47 secs with the current version. (processor: i5-2500K and ram: 16 GB ddr3).